### PR TITLE
fix: reactive isSnapped tracking

### DIFF
--- a/ui/src/main/java/com/open/pin/ui/components/button/Button.kt
+++ b/ui/src/main/java/com/open/pin/ui/components/button/Button.kt
@@ -328,7 +328,11 @@ fun PinButtonBase(
                 Modifier.magneticEffect(
                     enabled = true,
                     elementId = snapId
-                ) { interaction.isHovered = it }
+                ) { hovered -> 
+                    if (hovered || !interaction.isSnapped) {
+                        interaction.isHovered = hovered
+                    }
+                }
             } else Modifier
         )
         .then(
@@ -336,7 +340,10 @@ fun PinButtonBase(
                 Modifier.snappable(
                     id = snapId,
                     weight = effect.snapWeight,
-                    onSnap = { interaction.isSnapped = it }
+                    onSnap = { snapped ->
+                        interaction.isSnapped = snapped
+                        interaction.isHovered = snapped
+                    }
                 )
             } else Modifier
         )

--- a/ui/src/main/java/com/open/pin/ui/utils/modifiers/InteractionModifier.kt
+++ b/ui/src/main/java/com/open/pin/ui/utils/modifiers/InteractionModifier.kt
@@ -61,8 +61,10 @@ class InteractionElementState(
         )
     
     // Snap state tracking
-    val isSnapped by derivedStateOf {
-        enabled && coordinator.activeElementId.value == id
+    @Composable
+    fun isSnappedState(): State<Boolean> {
+        val activeElementId by coordinator.activeElementId.collectAsState()
+        return derivedStateOf { enabled && activeElementId == id }
     }
     
     /**
@@ -102,8 +104,9 @@ fun Modifier.interactionElement(
     onSnapChanged: ((Boolean) -> Unit)? = null
 ) = composed {
     // Effect to notify of snap state changes
-    LaunchedEffect(state.isSnapped) {
-        onSnapChanged?.invoke(state.isSnapped)
+    val isSnappedState by state.isSnappedState()
+    LaunchedEffect(isSnappedState) {
+        onSnapChanged?.invoke(isSnappedState)
     }
     
     // Register/unregister with the coordinator

--- a/ui/src/main/java/com/open/pin/ui/utils/modifiers/Magnet.kt
+++ b/ui/src/main/java/com/open/pin/ui/utils/modifiers/Magnet.kt
@@ -59,7 +59,7 @@ fun Modifier.magneticEffect(
     }
     
     // Track globally active element for persistence
-    val isGloballyActive = interactionState.isSnapped
+    val isGloballyActive by interactionState.isSnappedState()
     
     // Reset magnetic state when this element is no longer globally active
     LaunchedEffect(isGloballyActive) {


### PR DESCRIPTION
Snapped tracking wasn't actually triggering action handlers due to reactivity being lost. Properly pass through the flow so controls can react to their snapped status.

This fixes controls not being highlighted when the cursor was in the corresponding voronoi snap region for that control.