### PR TITLE
fix: apply magnetting anywhere in snap zone, not just on hover

### DIFF
--- a/ui/src/main/java/com/open/pin/ui/components/button/Button.kt
+++ b/ui/src/main/java/com/open/pin/ui/components/button/Button.kt
@@ -328,7 +328,11 @@ fun PinButtonBase(
                 Modifier.magneticEffect(
                     enabled = true,
                     elementId = snapId
-                ) { interaction.isHovered = it }
+                ) { hovered -> 
+                    if (hovered || !interaction.isSnapped) {
+                        interaction.isHovered = hovered
+                    }
+                }
             } else Modifier
         )
         .then(
@@ -336,7 +340,10 @@ fun PinButtonBase(
                 Modifier.snappable(
                     id = snapId,
                     weight = effect.snapWeight,
-                    onSnap = { interaction.isSnapped = it },
+                    onSnap = { snapped ->
+                        interaction.isSnapped = snapped
+                        interaction.isHovered = snapped
+                    },
                     onActivate = onClick
                 )
             } else Modifier

--- a/ui/src/main/java/com/open/pin/ui/utils/modifiers/InteractionModifier.kt
+++ b/ui/src/main/java/com/open/pin/ui/utils/modifiers/InteractionModifier.kt
@@ -39,7 +39,7 @@ class InteractionElementState(
     val id: String,
     val weight: Float,
     val enabled: Boolean,
-    private val coordinator: SnapCoordinator,
+    val coordinator: SnapCoordinator,
     private val onActivate: (() -> Unit)? = null
 ) {
     // Element position and size tracking

--- a/ui/src/main/java/com/open/pin/ui/utils/modifiers/InteractionModifier.kt
+++ b/ui/src/main/java/com/open/pin/ui/utils/modifiers/InteractionModifier.kt
@@ -64,8 +64,10 @@ class InteractionElementState(
         )
     
     // Snap state tracking
-    val isSnapped by derivedStateOf {
-        enabled && coordinator.activeElementId.value == id
+    @Composable
+    fun isSnappedState(): State<Boolean> {
+        val activeElementId by coordinator.activeElementId.collectAsState()
+        return derivedStateOf { enabled && activeElementId == id }
     }
     
     /**
@@ -105,8 +107,9 @@ fun Modifier.interactionElement(
     onSnapChanged: ((Boolean) -> Unit)? = null
 ) = composed {
     // Effect to notify of snap state changes
-    LaunchedEffect(state.isSnapped) {
-        onSnapChanged?.invoke(state.isSnapped)
+    val isSnappedState by state.isSnappedState()
+    LaunchedEffect(isSnappedState) {
+        onSnapChanged?.invoke(isSnappedState)
     }
     
     // Register/unregister with the coordinator

--- a/ui/src/main/java/com/open/pin/ui/utils/modifiers/Magnet.kt
+++ b/ui/src/main/java/com/open/pin/ui/utils/modifiers/Magnet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.geometry.Offset
 import com.open.pin.ui.utils.PinDimensions
 import kotlin.math.sqrt
@@ -34,36 +35,94 @@ fun Modifier.magneticEffect(
 ) = composed {
     // Hysteresis margin to prevent rapid in/out boundary switching
     val boundaryMargin = 8f
-    
+
     // Optimized movement parameters
     val damping = 0.7f // Interpolation factor for smooth movement
     val movementThreshold = 8f // Increased threshold to reduce update frequency
     val updateThrottleMs = 16L // Limit updates to ~60fps
-    
-    // Use shared interaction element state
-    val interactionState = rememberInteractionElementState(
-        id = elementId ?: remember { "magnetic-${java.util.UUID.randomUUID()}" },
-        enabled = enabled
-    )
-    
+
     var buttonOffset by remember { mutableStateOf(IntOffset(0, 0)) }
     var targetOffset by remember { mutableStateOf(Offset.Zero) } // Float precision target
     var lastMousePosition by remember { mutableStateOf(Offset.Zero) } // Track last position for threshold
     var isPointerInBounds by remember { mutableStateOf(false) }
     var isPressed by remember { mutableStateOf(false) }
     var lastUpdateTime by remember { mutableStateOf(0L) }
-    
+
     // Pre-calculate expensive values
-    val maxOffsetFloat by remember(maxOffset, sensitivity) { 
-        mutableStateOf(maxOffset * sensitivity) 
+    val maxOffsetFloat by remember(maxOffset, sensitivity) {
+        mutableStateOf(maxOffset * sensitivity)
     }
-    
+
+    fun updateMagneticPosition(position: Offset, elementSize: IntSize) {
+        val currentTime = System.currentTimeMillis()
+
+        // Throttle updates for better performance
+        if (currentTime - lastUpdateTime >= updateThrottleMs) {
+            // Check if mouse has moved enough to warrant position update
+            val deltaX = position.x - lastMousePosition.x
+            val deltaY = position.y - lastMousePosition.y
+            val movementDistanceSquared = deltaX * deltaX + deltaY * deltaY
+
+            // Use squared distance to avoid expensive sqrt calculation
+            if (movementDistanceSquared >= movementThreshold * movementThreshold) {
+                lastMousePosition = position
+                lastUpdateTime = currentTime
+
+                // Pre-calculate center values
+                val centerX = elementSize.width * 0.5f
+                val centerY = elementSize.height * 0.5f
+
+                // Optimized offset calculation
+                val normalizedX = (position.x - centerX) / centerX
+                val normalizedY = (position.y - centerY) / centerY
+
+                val newTargetX = normalizedX * maxOffsetFloat
+                val newTargetY = normalizedY * maxOffsetFloat
+
+                // Smooth interpolation toward target position
+                val currentTarget = targetOffset
+                targetOffset = Offset(
+                    x = currentTarget.x + (newTargetX - currentTarget.x) * damping,
+                    y = currentTarget.y + (newTargetY - currentTarget.y) * damping
+                )
+
+                // Only update buttonOffset if change is significant
+                val newButtonOffset =
+                    IntOffset(targetOffset.x.roundToInt(), targetOffset.y.roundToInt())
+                if (newButtonOffset != buttonOffset) {
+                    buttonOffset = newButtonOffset
+                }
+            }
+        }
+    }
+
+    // Use shared interaction element state (without callback initially)
+    val interactionState = rememberInteractionElementState(
+        id = elementId ?: remember { "magnetic-${java.util.UUID.randomUUID()}" },
+        enabled = enabled
+    )
+
     // Track globally active element for persistence
     val isGloballyActive by interactionState.isSnappedState()
-    
-    // Reset magnetic state when this element is no longer globally active
+
+    val globalCursorPosition by interactionState.coordinator.cursorPosition.collectAsState()
+
+    LaunchedEffect(globalCursorPosition, isGloballyActive) {
+        if (isGloballyActive && !isPointerInBounds && !isPressed) {
+            // Convert global position to local coordinates
+            val elementPosition = interactionState.elementPosition
+            val localPosition = Offset(
+                x = globalCursorPosition.x - elementPosition.x,
+                y = globalCursorPosition.y - elementPosition.y
+            )
+            updateMagneticPosition(localPosition, interactionState.elementSize)
+        }
+    }
+
     LaunchedEffect(isGloballyActive) {
-        if (!isGloballyActive && !isPointerInBounds) {
+        if (isGloballyActive) {
+            onHoverChanged?.invoke(true)
+        } else if (!isGloballyActive && !isPointerInBounds) {
             targetOffset = Offset.Zero
             buttonOffset = IntOffset(0, 0)
             onHoverChanged?.invoke(false)
@@ -83,89 +142,55 @@ fun Modifier.magneticEffect(
             awaitPointerEventScope {
                 while (true) {
                     val event = awaitPointerEvent()
-                    
+
                     when (event.type) {
                         PointerEventType.Enter -> {
                             isPointerInBounds = true
-                            lastMousePosition = event.changes.first().position // Reset for threshold calculation
+                            lastMousePosition =
+                                event.changes.first().position // Reset for threshold calculation
                             if (!isPressed) {
                                 onHoverChanged?.invoke(true)
                             }
                         }
+
                         PointerEventType.Move -> {
                             val position = event.changes.first().position
-                            
+
                             // Check if pointer is still within the bounds of this element
                             // Use hysteresis to prevent rapid boundary switching
                             val wasInBounds = isPointerInBounds
                             val margin = if (wasInBounds) boundaryMargin else -boundaryMargin
-                            isPointerInBounds = position.x >= -margin && position.x <= size.width + margin &&
-                                    position.y >= -margin && position.y <= size.height + margin
-                            
-                            // Skip magnetic positioning when pressed to eliminate jitter
+                            isPointerInBounds =
+                                position.x >= -margin && position.x <= size.width + margin &&
+                                        position.y >= -margin && position.y <= size.height + margin
+
+                            // Apply magnetic positioning when pointer is in bounds OR when globally active
                             if (isPointerInBounds && !isPressed) {
-                                val currentTime = System.currentTimeMillis()
-                                
-                                // Throttle updates for better performance
-                                if (currentTime - lastUpdateTime >= updateThrottleMs) {
-                                    // Check if mouse has moved enough to warrant position update
-                                    val deltaX = position.x - lastMousePosition.x
-                                    val deltaY = position.y - lastMousePosition.y
-                                    val movementDistanceSquared = deltaX * deltaX + deltaY * deltaY
-                                    
-                                    // Use squared distance to avoid expensive sqrt calculation
-                                    if (movementDistanceSquared >= movementThreshold * movementThreshold) {
-                                        lastMousePosition = position
-                                        lastUpdateTime = currentTime
-                                        
-                                        // Pre-calculate center values
-                                        val centerX = size.width * 0.5f
-                                        val centerY = size.height * 0.5f
-                                        
-                                        // Optimized offset calculation
-                                        val normalizedX = (position.x - centerX) / centerX
-                                        val normalizedY = (position.y - centerY) / centerY
-                                        
-                                        val newTargetX = normalizedX * maxOffsetFloat
-                                        val newTargetY = normalizedY * maxOffsetFloat
-                                        
-                                        // Smooth interpolation toward target position
-                                        val currentTarget = targetOffset
-                                        targetOffset = Offset(
-                                            x = currentTarget.x + (newTargetX - currentTarget.x) * damping,
-                                            y = currentTarget.y + (newTargetY - currentTarget.y) * damping
-                                        )
-                                        
-                                        // Only update buttonOffset if change is significant
-                                        val newButtonOffset = IntOffset(targetOffset.x.roundToInt(), targetOffset.y.roundToInt())
-                                        if (newButtonOffset != buttonOffset) {
-                                            buttonOffset = newButtonOffset
-                                        }
-                                    }
-                                }
+                                updateMagneticPosition(position, IntSize(size.width, size.height))
                             } else {
                                 // Only reset position if this element is no longer globally active
                                 if (!isGloballyActive && (targetOffset != Offset.Zero || buttonOffset != IntOffset.Zero)) {
                                     targetOffset = Offset.Zero
                                     buttonOffset = IntOffset.Zero
                                 }
-                                
+
                                 // But only update hover state if not pressing and not globally active
                                 if (!isPressed && wasInBounds && !isGloballyActive) {
                                     onHoverChanged?.invoke(false)
                                 }
                             }
                         }
+
                         PointerEventType.Exit -> {
                             // Mark as no longer in bounds
                             isPointerInBounds = false
-                            
+
                             // Only reset position if this element is no longer globally active
                             if (!isGloballyActive) {
                                 targetOffset = Offset.Zero
                                 buttonOffset = IntOffset(0, 0)
                             }
-                            
+
                             // Only update hover state if not pressing and not globally active
                             if (!isPressed && !isGloballyActive) {
                                 onHoverChanged?.invoke(false)
@@ -177,7 +202,7 @@ fun Modifier.magneticEffect(
                         PointerEventType.Release -> {
                             val wasPressed = isPressed
                             isPressed = false
-                            
+
                             // When released, update hover state based on current position
                             if (wasPressed) {
                                 onHoverChanged?.invoke(isPointerInBounds)

--- a/ui/src/main/java/com/open/pin/ui/utils/modifiers/Magnet.kt
+++ b/ui/src/main/java/com/open/pin/ui/utils/modifiers/Magnet.kt
@@ -59,7 +59,7 @@ fun Modifier.magneticEffect(
     }
     
     // Track globally active element for persistence
-    val isGloballyActive = interactionState.isSnapped
+    val isGloballyActive by interactionState.isSnappedState()
     
     // Reset magnetic state when this element is no longer globally active
     LaunchedEffect(isGloballyActive) {


### PR DESCRIPTION
Merge after #7.

Currently, magnetting only applies when the cursor is directly over top of the button. Instead apply it when the cursor is anywhere in the applicable snap zone, if one is enabled.